### PR TITLE
[EXPERIMENTAL] Allow sending of full skeleton data without rotation

### DIFF
--- a/bin/backends.py
+++ b/bin/backends.py
@@ -136,7 +136,7 @@ class SteamVRBackend(Backend):
             else:
                 for i in range(23):
                     joint = pose3d[i] - offset      #if previewing skeleton, send the position of each keypoint to steamvr without rotation
-                    sendToSteamVR(f"updatepose {i} {joint[0]} {joint[1]} {joint[2] - 2} 1 0 0 0 {params.camera_latency} 0.8")
+                    sendToSteamVR(f"updatepose {i} {joint[0]} {joint[1]} {joint[2]} 1 0 0 0 {params.camera_latency} 0.8")
         return True
 
     def disconnect(self):


### PR DESCRIPTION
This PR removes the 2 meter offset of the skeleton preview mode, made for use cases where only joint positions are needed, not rotations.

Note that this will not work with most applications such as VRChat, those need the joint rotations calculated.

To use the feature, simply activate the "[DEV] Preview whole skeleton" option.