### PR TITLE
Enable a webui for calibration

### DIFF
--- a/bin/inference_gui.py
+++ b/bin/inference_gui.py
@@ -11,6 +11,7 @@ class InferenceWindow(tk.Frame):
         tk.Frame.__init__(self, root, *args, **kwargs)
         
         self.params = params
+        params.gui = self       #uhh is this a good idea?
         self.root = root
 
         # calibrate rotation
@@ -417,8 +418,6 @@ def make_inference_gui(_params):
     InferenceWindow(root, _params).pack(side="top", fill="both", expand=True)
     root.mainloop()
     
-def start_inference_gui(root):
-    root.mainloop()
 
 if __name__ == "__main__":
     #make_inference_gui()

--- a/bin/inference_gui.py
+++ b/bin/inference_gui.py
@@ -416,6 +416,9 @@ def make_inference_gui(_params):
     root = tk.Tk()
     InferenceWindow(root, _params).pack(side="top", fill="both", expand=True)
     root.mainloop()
+    
+def start_inference_gui(root):
+    root.mainloop()
 
 if __name__ == "__main__":
     #make_inference_gui()

--- a/bin/init_gui.py
+++ b/bin/init_gui.py
@@ -69,6 +69,8 @@ def getparams():
         param["backend_port"] = 9000
     if "advanced" not in param:
         param["advanced"] = False
+    if "webui" not in param:
+        param["webui"] = False
        
     window = tk.Tk()
 
@@ -189,6 +191,11 @@ def getparams():
     show_hide_backend_options()
     backend_frame.pack()
 
+    tk.Label(text="-"*50, width = 50).pack()
+
+    varwebui = tk.IntVar(value = param["webui"])
+    webui_check = tk.Checkbutton(text = "Enable webui to control parameters from another device", variable = varwebui)
+    webui_check.pack()
     
     param["switch_advanced"] = False
     if param["advanced"]:
@@ -200,6 +207,8 @@ def getparams():
     tk.Button(text='Save and Continue', command=window.quit).pack()
 
     window.mainloop()
+
+#----------------------------------------------------------"
 
     cameraid = camid.get()
     #hmd_to_neck_offset = [float(val) for val in hmdoffsettext.get().split(" ")]
@@ -218,6 +227,8 @@ def getparams():
     backend = int(varbackend.get())
     backend_ip_set = backend_ip.get()
     backend_port_set = int(backend_port.get())
+    
+    webui = bool(varwebui.get())
     
     if param["advanced"]:
         maximgsize = int(maximgsize.get())
@@ -269,6 +280,7 @@ def getparams():
     param["backend"] = backend
     param["backend_ip"] = backend_ip_set
     param["backend_port"] = backend_port_set
+    param["webui"] = webui
     
     if switch_advanced:
         param["advanced"] = not advanced

--- a/bin/mediapipepose.py
+++ b/bin/mediapipepose.py
@@ -13,9 +13,12 @@ import numpy as np
 from helpers import  CameraStream, shutdown, mediapipeTo3dpose, get_rot_mediapipe, get_rot_hands, draw_pose, keypoints_to_original, normalize_screen_coordinates, get_rot
 from scipy.spatial.transform import Rotation as R
 from backends import DummyBackend, SteamVRBackend, VRChatOSCBackend
+import webui
 
 import inference_gui
 import parameters
+
+import tkinter as tk
 
 import mediapipe as mp
 
@@ -25,10 +28,13 @@ def main():
     mp_pose = mp.solutions.pose
 
     use_steamvr = True
-
+    
     print("INFO: Reading parameters...")
 
     params = parameters.Parameters()
+    
+    webui_thread = threading.Thread(target=webui.start_webui, args=(params,), daemon=True)
+    webui_thread.start()
 
     backends = { 0: DummyBackend, 1: SteamVRBackend, 2: VRChatOSCBackend }
     backend = backends[params.backend]()
@@ -41,6 +47,7 @@ def main():
 
     camera_thread = CameraStream(params)
 
+    #making gui
     gui_thread = threading.Thread(target=inference_gui.make_inference_gui, args=(params,), daemon=True)
     gui_thread.start()
 

--- a/bin/mediapipepose.py
+++ b/bin/mediapipepose.py
@@ -33,8 +33,11 @@ def main():
 
     params = parameters.Parameters()
     
-    webui_thread = threading.Thread(target=webui.start_webui, args=(params,), daemon=True)
-    webui_thread.start()
+    if params.webui:
+        webui_thread = threading.Thread(target=webui.start_webui, args=(params,), daemon=True)
+        webui_thread.start()
+    else:
+        print("INFO: WebUI disabled in parameters")
 
     backends = { 0: DummyBackend, 1: SteamVRBackend, 2: VRChatOSCBackend }
     backend = backends[params.backend]()

--- a/bin/parameters.py
+++ b/bin/parameters.py
@@ -40,6 +40,8 @@ class Parameters():
         self.backend = param["backend"]
         self.backend_ip = param["backend_ip"]
         self.backend_port = param["backend_port"]
+        
+        self.webui = param["webui"]
 
         self.calib_rot = True
         self.calib_tilt = True

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -2,3 +2,4 @@ opencv-python
 numpy
 scipy
 mediapipe
+flask

--- a/bin/templates/index – kopija.html
+++ b/bin/templates/index – kopija.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<style>
+  
+.rangeslider{
+    width: 50%;
+}
+  
+.myslider {
+    -webkit-appearance: none;
+    background: #FCF3CF  ;
+    width: 50%;
+    height: 20px;
+    opacity: 2;
+   }
+  
+  
+.myslider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    cursor: pointer;
+    background: #34495E  ;
+    width: 5%;
+    height: 20px;
+}
+  
+  
+.myslider:hover {
+    opacity: 1;
+}
+  
+</style>
+<body>
+  
+<h1>Example of Range Slider Using Javascript</h1>
+<p>Use the slider to increment or decrement value.</p>
+  
+<div class="rangeslider">
+  <input type="range" min="1" max="100" value="10"
+                  class="myslider" id="sliderRange">
+  <p>Value: <span id="demo"></span></p>
+</div>
+  
+<script>
+var rangeslider = document.getElementById("sliderRange");
+var output = document.getElementById("demo");
+output.innerHTML = rangeslider.value;
+  
+rangeslider.oninput = function() {
+  output.innerHTML = this.value;
+}
+</script>
+  
+</body>
+</html>

--- a/bin/templates/index.html
+++ b/bin/templates/index.html
@@ -67,7 +67,9 @@
 		<form action = "/smoothing" method = "post" class="form-inline">
 			 <p>Additional smoothing:</p>
 			 <p><input type = "text" name = "value" value="{{smooth}}" class="form-button" /></p>
-			 <p><input type = "submit" value = "Update" class="form-button" /></p>
+			 <p><input type = "submit" value = "Update" class="form-button" name = "action" /></p>
+			 <p><input class="form-button" type = "submit" name = "action" value = "<" /></p>
+			 <p><input class="form-button" type = "submit" name = "action" value = ">" /></p>
 		 </form>
 	
 </body>

--- a/bin/templates/index.html
+++ b/bin/templates/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>FlaskApp</title>
+</head>
+<style>
+  
+.form-button {
+	width: 200px;
+	height: 50px;
+	margin: 10px;}
+	
+.wide-button {
+	width: 400px;
+	height: 50px;
+	margin: 10px;}
+	
+.form-inline {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  margin: 0px;
+}
+  
+</style>
+<body>
+    <h1>Hello {{name}}!</h1>
+    <h2>Update rotation Y</h2>
+		<form action = "/roty" method = "post" class="form-inline">
+			
+			<p><input class="form-button" type = "submit" name = "action" value = "<<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = "<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">>" /></p>
+		</form>
+	<h2>Update rotation X</h2>
+		<form action = "/rotx" method = "post" class="form-inline">
+			
+			<p><input class="form-button" type = "submit" name = "action" value = "<<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = "<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">>" /></p>
+		</form>
+	<h2>Update rotation Z</h2>
+		<form action = "/rotz" method = "post" class="form-inline">
+			
+			<p><input class="form-button" type = "submit" name = "action" value = "<<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = "<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">>" /></p>
+		</form>
+	<h2>Update Scale</h2>
+		<form action = "/scale" method = "post" class="form-inline">
+			
+			<p><input class="form-button" type = "submit" name = "action" value = "<<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = "<" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">" /></p>
+			<p><input class="form-button" type = "submit" name = "action" value = ">>" /></p>
+		</form>
+	
+		<form action = "/autocalib" method = "post" class="form-inline">
+			<p><input class="wide-button" type = "submit" value = "Autocalibrate" /></p>	
+		</form>
+		
+	<h2>Update Smoothing</h2>	
+		<form action = "/smoothing" method = "post" class="form-inline">
+			 <p>Additional smoothing:</p>
+			 <p><input type = "text" name = "value" value="{{smooth}}" class="form-button" /></p>
+			 <p><input type = "submit" value = "Update" class="form-button" /></p>
+		 </form>
+	
+</body>
+</html>

--- a/bin/webui.py
+++ b/bin/webui.py
@@ -1,0 +1,69 @@
+# Importing flask module in the project is mandatory
+# An object of Flask class is our WSGI application.
+from flask import Flask, render_template, request, redirect, url_for
+
+params = None
+
+# Flask constructor takes the name of
+# current module (__name__) as argument.
+app = Flask(__name__)
+ 
+# The route() function of the Flask class is a decorator,
+# which tells the application which URL should call
+# the associated function.
+@app.route('/')
+# ‘/’ URL is bound with hello_world() function.
+def hello_world():
+    return render_template('index.html', name="there", smooth=params.additional_smoothing)
+    
+@app.route('/smoothing', methods=["POST"])
+def smoothing():
+    params.change_additional_smoothing(float(request.form["value"]),paramid=1)
+    return redirect(url_for("hello_world"))
+    
+options = {
+"<<":-10,
+"<":-1,
+">":1,
+">>":10}
+
+@app.route('/roty', methods=["POST"])
+def roty():
+    cur = params.euler_rot_y
+    change = options[request.form["action"]]
+    params.rot_change_y(cur+change)
+    return redirect(url_for("hello_world"))
+    
+@app.route('/rotx', methods=["POST"])
+def rotx():
+    cur = params.euler_rot_x
+    change = options[request.form["action"]]
+    params.rot_change_x(cur+change)
+    return redirect(url_for("hello_world"))
+    
+@app.route('/rotz', methods=["POST"])
+def rotz():
+    cur = params.euler_rot_z
+    change = options[request.form["action"]]
+    params.rot_change_z(cur+change)
+    return redirect(url_for("hello_world"))
+    
+@app.route('/scale', methods=["POST"])
+def scale():
+    cur = params.posescale
+    change = options[request.form["action"]] /100
+    params.change_scale(cur+change)
+    return redirect(url_for("hello_world"))
+    
+@app.route('/autocalib', methods=["POST"])
+def autocalib():
+    params.change_recalibrate()
+    return redirect(url_for("hello_world"))
+ 
+# main driver function
+def start_webui(param):
+    global params
+    params=param
+    # run() method of Flask class runs the application
+    # on the local development server.
+    app.run(host="0.0.0.0")

--- a/bin/webui.py
+++ b/bin/webui.py
@@ -2,6 +2,8 @@
 # An object of Flask class is our WSGI application.
 from flask import Flask, render_template, request, redirect, url_for
 
+import numpy as np
+
 params = None
 
 # Flask constructor takes the name of
@@ -14,11 +16,16 @@ app = Flask(__name__)
 @app.route('/')
 # ‘/’ URL is bound with hello_world() function.
 def hello_world():
-    return render_template('index.html', name="there", smooth=params.additional_smoothing)
+    return render_template('index.html', name="there", smooth=np.round(params.additional_smoothing,2))
     
 @app.route('/smoothing', methods=["POST"])
 def smoothing():
-    params.change_additional_smoothing(float(request.form["value"]),paramid=1)
+    if request.form["action"] in options.keys():
+        newvalue = params.additional_smoothing + 0.1*options[request.form["action"]]
+    else:
+        newvalue = float(request.form["value"])
+    newvalue = np.clip(newvalue,0,1)
+    params.change_additional_smoothing(newvalue,paramid=1)
     return redirect(url_for("hello_world"))
     
 options = {
@@ -57,7 +64,7 @@ def scale():
     
 @app.route('/autocalib', methods=["POST"])
 def autocalib():
-    params.change_recalibrate()
+    params.gui.autocalibrate()
     return redirect(url_for("hello_world"))
  
 # main driver function

--- a/bin/webui.py
+++ b/bin/webui.py
@@ -73,4 +73,6 @@ def start_webui(param):
     params=param
     # run() method of Flask class runs the application
     # on the local development server.
+    print("INFO: Starting WebUI!")
+    print("INFO: To access the webui, simply open the second Running on IP address on your quests browser!")
     app.run(host="0.0.0.0")


### PR DESCRIPTION
This PR creates a simple webui to allow control of main calibration values without access to the main computer MPP is running on, such as when using Quest standalone.

Main purpose of this is to simplify use on standalone quest. How to use:
1. Use the first GUI normally. Make sure to use OSC backend and enter the quests IP address.
2. When starting, the console should print something like ```Running on http://192.168.0.12:5000```. Remember this address. (the last one, NOT the 127.0.0.1 one!)
3. Check that the image covers your entire playspace, and ensure Image rotation is enabled in case your camera is sideways (you cannot control this from the webui)
4. Go into VRChat on quest and enable OSC. You should now have the option to calibrate FBT. Click the option, but dont press both triggers to calibrate yet.
5. Open web browser on Quest, and enter the IP from before into the address bar. It should open a terrible looking GUI.
6. First, press the Autocalibrate button to get a rough calibration. Then, use the Rotation y buttons to allign the skeleton with your legs, and finally change the Scale until the calibration balls are at your ankles.
7. Close the web browser, tpose and press both triggers to calibrate avatar in VRChat.

*NOTE: this actually hasnt been tested on standalone quest yet, so please report any issues to the discord! (or open an issue on github if you prefer that)